### PR TITLE
Fix string formatting error

### DIFF
--- a/test_reader.py
+++ b/test_reader.py
@@ -31,7 +31,7 @@ def evaluate(model, dataset, dataloader, tokenizer, opt):
     exactmatch = []
     if opt.write_results:
         write_path = Path(opt.checkpoint_dir) / opt.name / 'test_results'
-        fw = open(write_path / '%d.txt'%opt.global_rank, 'a')
+        fw = open(write_path / ('%d.txt'%opt.global_rank), 'a')
     with torch.no_grad():
         for i, batch in enumerate(dataloader):
             (idx, _, _, context_ids, context_mask) = batch


### PR DESCRIPTION
When the `test_reader.py` script is used with the `--write_results` flag, the following error is thrown:

```
Traceback (most recent call last):
  File "test_reader.py", line 129, in <module>
    exactmatch, total = evaluate(model, eval_dataset, eval_dataloader, tokenizer, opt)
  File "test_reader.py", line 34, in evaluate
    fw = open(write_path / '%d.txt'%opt.global_rank, 'a')
TypeError: unsupported operand type(s) for %: 'PosixPath' and 'int'
```

This patch fixes the order of operations.