### PR TITLE
added the option pad_to_max_length

### DIFF
--- a/src/options.py
+++ b/src/options.py
@@ -89,6 +89,7 @@ class Options():
                         help='save model every <save_freq> steps during training')
         self.parser.add_argument('--eval_print_freq', type=int, default=1000,
                         help='print intermdiate results of evaluation every <eval_print_freq> steps')
+        self.parser.add_argument('--pad_to_max_length', action='store_true', help='Should the passages all be padded to the max length provided (True value here), or to the max length of the longest passage? (False value here).')
 
 
     def print_options(self, opt):

--- a/test_reader.py
+++ b/test_reader.py
@@ -35,7 +35,7 @@ def evaluate(model, dataset, dataloader, tokenizer, opt):
     with torch.no_grad():
         for i, batch in enumerate(dataloader):
             (idx, _, _, context_ids, context_mask) = batch
-
+            
             if opt.write_crossattention_scores:
                 model.reset_score_storage()
 
@@ -101,7 +101,7 @@ if __name__ == "__main__":
 
     tokenizer = transformers.T5Tokenizer.from_pretrained('t5-base', return_dict=False)
 
-    collator_function = src.data.Collator(opt.text_maxlength, tokenizer)
+    collator_function = src.data.Collator(opt.text_maxlength, tokenizer, pad_to_max_length=opt.pad_to_max_length)
     eval_examples = src.data.load_data(
         opt.eval_data, 
         global_rank=opt.global_rank, #use the global rank and world size attibutes to split the eval set on multiple gpus

--- a/train_reader.py
+++ b/train_reader.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
 
     #load data
     tokenizer = transformers.T5Tokenizer.from_pretrained(model_name)
-    collator = src.data.Collator(opt.text_maxlength, tokenizer, answer_maxlength=opt.answer_maxlength)
+    collator = src.data.Collator(opt.text_maxlength, tokenizer, answer_maxlength=opt.answer_maxlength, pad_to_max_length=opt.pad_to_max_length)
 
     # use golbal rank and world size to split the eval set on multiple gpus
     train_examples = src.data.load_data(


### PR DESCRIPTION
added the option pad_to_max_length, which enables to either use the max length specified, or compute the max length present in the batch dynamically. 

The default is to use the dynamic computation, since it is much cheaper in terms of memory consumption. 