### PR TITLE
fix: Fix typing and import bugs

### DIFF
--- a/passage_retrieval.py
+++ b/passage_retrieval.py
@@ -143,7 +143,7 @@ def main(opt):
         index_encoded_data(index, input_paths, opt.indexing_batch_size)
         logger.info(f'Indexing time: {time.time()-start_time_indexing:.1f} s.')
         if args.save_or_load_index:
-            src.index.serialize(embeddings_dir)
+            index.serialize(embeddings_dir)
 
     questions_embedding = embed_questions(opt, data, model, tokenizer)
 

--- a/src/index.py
+++ b/src/index.py
@@ -52,7 +52,7 @@ class Indexer(object):
         meta_file = dir_path / 'index_meta.dpr'
         logger.info(f'Serializing index to {index_file}, meta data to {meta_file}')
 
-        faiss.write_index(self.index, index_file)
+        faiss.write_index(self.index, str(index_file))
         with open(meta_file, mode='wb') as f:
             pickle.dump(self.index_id_to_db_id, f)
 
@@ -61,7 +61,7 @@ class Indexer(object):
         meta_file = dir_path / 'index_meta.dpr'
         logger.info(f'Loading index from {index_file}, meta data from {meta_file}')
 
-        self.index = faiss.read_index(index_file)
+        self.index = faiss.read_index(str(index_file))
         logger.info('Loaded index of type %s and size %d', type(self.index), self.index.ntotal)
 
         with open(meta_file, "rb") as reader:

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -6,7 +6,6 @@
 
 import sys
 import json
-import parser
 from pathlib import Path
 import numpy as np
 import util


### PR DESCRIPTION
Fix bugs in the inference pipeline:
src/preprocess.py: remove never used `import parser` which is not referenced in requirements.txt and causes issues when running
passage_retrieval.py: fix reference bug `src.index.serialize => index.serialize`
src/index.py: `index_file -> str(index_file)` faiss expects string but gets Path object instead.